### PR TITLE
Protect from forgery disabled for creating via api

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ReservationsController < ApplicationController
-  protect_from_forgery unless: -> { request.format.json? }
+  protect_from_forgery except: :create_without_registration
   before_action :set_screening, only: %i[new create create_at_desk create_without_registration]
   before_action :set_reservation, only: %i[confirm cancel]
   before_action :authenticate_user!, except: %i[new create_without_registration]


### PR DESCRIPTION
- changing config to disable csrf token only for create without registration