### PR TITLE
[Bug]  fix create links method, style date links

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -160,3 +160,12 @@ footer a:hover {
 .bg-lightgray {
   background-color: #F4F4F4 !important;
 }
+
+.date-links a{
+  text-decoration: none !important;
+  color: #000 !important;
+}
+
+.date-links a:hover {
+  color: #ffc107 !important;  
+}

--- a/app/helpers/screening_helper.rb
+++ b/app/helpers/screening_helper.rb
@@ -6,7 +6,7 @@ module ScreeningHelper
     content_tag(:ul, class: "d-flex mb-3") do
       DAYS_NUMBER.times do |num|
         concat(link_to((Time.zone.today + num.days).strftime("%a %d/%m"),
-          movies_path(start_time: Time.zone.today + num.days), class: "mx-2",))
+          request.params.merge(start_time: Time.zone.today + num.days), class: "mx-2",))
       end
     end
   end

--- a/app/helpers/screening_helper.rb
+++ b/app/helpers/screening_helper.rb
@@ -3,10 +3,10 @@
 module ScreeningHelper
   DAYS_NUMBER = 7
   def create_date_links
-    content_tag(:ul, class: "d-flex mb-3") do
+    content_tag(:ul, class: "d-flex mb-3 date-links") do
       DAYS_NUMBER.times do |num|
         concat(link_to((Time.zone.today + num.days).strftime("%a %d/%m"),
-          request.params.merge(start_time: Time.zone.today + num.days), class: "mx-2",))
+          request.params.merge(start_time: Time.zone.today + num.days), class: "mx-2 p-4 fs-5 fw-normal",))
       end
     end
   end


### PR DESCRIPTION
- create links method was always redirecting to movies index path, now it merge query params into the new url
- new style for date links was introduced 
<img width="1248" alt="Screenshot 2023-08-26 at 21 28 00" src="https://github.com/danyflorczak/Monte_Cinema/assets/71887549/4d76d229-65ab-4a13-8862-b928afc7d4bd">
